### PR TITLE
Tri des champs des objets GraphQL

### DIFF
--- a/apollo-server/type-defs.js
+++ b/apollo-server/type-defs.js
@@ -10,7 +10,7 @@ import { parse, Kind, buildASTSchema, print } from 'graphql'
  * @param {string} dossier Base du chemin relatif du fichier à importer.
  * @returns {GraphQLSchema} Schéma GraphQL résultant de l'importation et de la fusion des types.
  */
-const importerSchema = (fichier, dossier = __dirname) => {
+const importerSchema = (fichier, { dossier = __dirname, trier = false } = {}) => {
   const charge = new Map()
   const importer = (_fichier, _dossier) => {
     const chemin = path.resolve(_dossier, _fichier)
@@ -39,16 +39,23 @@ const importerSchema = (fichier, dossier = __dirname) => {
       return arr
     }, actuel.directives)
   }
+  const trierParNom = tableau => trier
+    ? trier instanceof Function
+      ? tableau.sort(trier)
+      : tableau.sort((a, b) => a.name.value.localeCompare(b.name.value))
+    : undefined
   const fusionChamps = (actuel, nouveau) => {
     actuel.fields.push(...nouveau.fields)
+    trierParNom(actuel.fields)
     fusionDirectives(actuel, nouveau)
   }
   const fusionValeurs = (actuel, nouveau) => {
     actuel.values.push(...nouveau.values)
+    trierParNom(actuel.values)
     fusionDirectives(actuel, nouveau)
   }
   const aucuneFusion = () => {
-    // Ce type ne peut être fusionné.
+    // Ce type ne nécessite pas de fusion.
   }
   const fusions = {
     [Kind.INPUT_OBJECT_TYPE_DEFINITION]: fusionChamps,
@@ -65,13 +72,21 @@ const importerSchema = (fichier, dossier = __dirname) => {
     for (let source of sources)
       if (source.length)
         for (let definition of parse(source, { noLocation: true }).definitions)
-          if (definition.name && definitionsParNom.has(definition.name.value))
-            if (fusions[definition.kind])
+          if ('name' in definition && definitionsParNom.has(definition.name.value))
+            if (definition.kind in fusions)
               fusions[definition.kind](definitionsParNom.get(definition.name.value), definition)
             else
               console.warn(`Le type GraphQL « ${definition.kind} » ne peut être fusionné.`)
-          else
-            definitionsParNom.set(definition.name ? definition.name.value : definition, definition)
+          else {
+            if ('fields' in definition)
+              trierParNom(definition.fields)
+            if ('values' in definition)
+              trierParNom(definition.values)
+            definitionsParNom.set(
+              definition.name ? definition.name.value : definition,
+              definition
+            )
+          }
   }
   const recreerDocument = definitions => ({
     kind: 'Document',
@@ -88,7 +103,7 @@ const importerSchema = (fichier, dossier = __dirname) => {
   return document
 }
 
-const document = importerSchema('schema.graphql')
+const document = importerSchema('schema.graphql', { trier: true })
 
 export const schema = buildASTSchema(document)
 


### PR DESCRIPTION
## Problème

Actuellement, les champs dans les objets GraphQL (ex: `Query`, `Mutation` ou encore `Niveau`) ne sont pas triés. Leur ordre dépend donc de l'ordre d'importation des différents fichiers GraphQL étendant le même objet.

Un gros inconvénient de cette méthode est que dans l’utilitaire *GraphQL Playground*, fourni par *ApolloServer*, les champs sont affichés dans l'ordre dans lequel ils apparaissent dans le schéma, rendant difficile la recherche d'un champ en particulier notamment.

## Solution

Cette *Pull Request* corrige ce problème en triant par ordre alphabétique les champs des objets GraphQL lors de l'importation.