### PR TITLE
Archived - Extension de la validation des entrées GraphQL

### DIFF
--- a/apollo-server/composants/erreur/index.js
+++ b/apollo-server/composants/erreur/index.js
@@ -4,7 +4,7 @@ import { MODE_DEVELOPPEMENT } from '../config'
 
 export default class CodinSchoolError extends ApolloError {
   constructor(code, message, props, details) {
-    super(message, code, { props, details: MODE_DEVELOPPEMENT ? details : undefined })
+    super(message, code, { ...props, details: MODE_DEVELOPPEMENT ? details : undefined })
   }
 }
 

--- a/apollo-server/composants/niveau/index.graphql
+++ b/apollo-server/composants/niveau/index.graphql
@@ -27,8 +27,15 @@ Paramètres demandés lors de la création d'un Niveau.
 """
 input CreationNiveau {
   id: ID!
+  @min(longueur: 3)
+  @max(longueur: 31)
+
   titre: String!
+  @min(longueur: 3)
+  @max(longueur: 137)
+  
   introduction: String
+  @max(longueur: 5000)
 }
 
 """
@@ -36,6 +43,13 @@ Paramètres demandés lors de l'édition d'un Niveau.
 """
 input EditionNiveau {
   id: ID
+  @min(longueur: 3)
+  @max(longueur: 31)
+
   titre: String
+  @min(longueur: 3)
+  @max(longueur: 137)
+  
   introduction: String
+  @max(longueur: 5000)
 }

--- a/apollo-server/composants/validation/Directive.js
+++ b/apollo-server/composants/validation/Directive.js
@@ -1,0 +1,122 @@
+import { GraphQLNonNull, GraphQLList } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+import { ValidationError, erreurInattendueProbleme } from './ValidationErreurs'
+
+const VALIDATIONS = Symbol()
+const DEJA_PROTEGE = Symbol()
+
+const decapsuler = (type, classe = null) =>
+  (classe ? type instanceof classe : 'ofType' in type)
+    ? decapsuler(type.ofType, classe)
+    : type
+
+const gererErreurValidation = async (promesse, problemes, emplacement) => {
+  try {
+    await promesse()
+  }
+  catch (err) {
+    if (err instanceof ValidationError)
+      err.problemes.forEach(x => problemes.push(x))
+    else
+      problemes.push(erreurInattendueProbleme(emplacement, err))
+  }
+}
+
+const validerToutes = async (promesses) => {
+  let problemes = []
+  for (let [promesse, emplacement] of promesses)
+    await gererErreurValidation(() => promesse, problemes, emplacement)
+  if (problemes.length)
+    throw new ValidationError(...problemes)
+}
+
+// eslint-ignore no-use-before-define
+const validerArgument = async (validations, valeur, type, emplacement, problemes) => {
+  const shouldThrow = problemes === null
+  if (shouldThrow)
+    problemes = []
+  if (validations)
+    for (let validation of validations)
+      await gererErreurValidation(() => validation(valeur, emplacement), problemes, emplacement)
+  if (type instanceof GraphQLList) {
+    type = decapsuler(type.ofType, GraphQLNonNull)
+    for (let i = 0; i < valeur.length; i++)
+      await validerArgument(null, valeur[i], type, `${emplacement}[${i}]`, problemes)
+  }
+  else
+    // eslint-disable-next-line
+    await gererErreurValidation(() => validerTypeEtArguments(type, valeur, emplacement), problemes, emplacement)
+  if (shouldThrow && problemes.length)
+    throw new ValidationError(...problemes)
+}
+
+async function validerTypeEtArguments(type, args, emplacement) {
+  if (type[VALIDATIONS])
+    for (let validation of type[VALIDATIONS])
+      await validation(args, emplacement)
+  if ('getFields' in type) {
+    /** @type {import('graphql').GraphQLField<any, any>} */
+    let champ
+    const problemes = []
+    for (champ of Object.values(type.getFields()))
+      if (champ.name in args)
+        await validerArgument(champ[VALIDATIONS], args[champ.name], decapsuler(champ.type, GraphQLNonNull), `${emplacement}.${champ.name}`, problemes)
+    if (problemes.length)
+      throw new ValidationError(...problemes)
+  }
+}
+
+const assurerSchemaProteges = schema => {
+  if (!schema[DEJA_PROTEGE]) {
+    schema[DEJA_PROTEGE] = true
+    for (let objetType of Object.values(schema.getTypeMap()))
+      if ('getFields' in objetType && !objetType.name.startsWith('__')) {
+        /** @type {import('graphql').GraphQLField<any, any>} */
+        let champAProteger
+        for (champAProteger of Object.values(objetType.getFields()))
+          if (champAProteger.resolve && champAProteger.args && champAProteger.args.length && !champAProteger.name.startsWith('__')) {
+            const resoudre = champAProteger.resolve
+            /** @type {Map<string, [import('graphql').GraphQLInputType, import('graphql').GraphQLArgument]>} */
+            const argsMap = champAProteger.args.reduce((map, cour) => map.set(cour.name, [decapsuler(cour.type, GraphQLNonNull), cour]), new Map())
+            // eslint-disable-next-line
+            champAProteger.resolve = function (_, args, __, info) {
+              const pending = []
+              if (argsMap.size) {
+                for (let arg of Object.keys(args)) {
+                  if (argsMap.has(arg)) {
+                    const [type, argDef] = argsMap.get(arg)
+                    pending.push([validerArgument(argDef[VALIDATIONS], args[arg], type, `${info.path.key}:${argDef.name}`, null), `${info.path.key}:${argDef.name}`])
+                  }
+                }
+                if (pending.length)
+                  return validerToutes(pending).then(() => resoudre.apply(this, arguments))
+              }
+              else
+                champAProteger.resolve = resoudre
+              return resoudre.apply(this, arguments)
+            }
+          }
+      }
+  }
+}
+
+export default validateur => class DirectiveValidation extends SchemaDirectiveVisitor {
+  visitArgumentDefinition(arg) {
+    assurerSchemaProteges(this.schema)
+    if (!arg[VALIDATIONS])
+      arg[VALIDATIONS] = []
+    arg[VALIDATIONS].push(validateur(this.args))
+  }
+  visitInputObject(objet) {
+    assurerSchemaProteges(this.schema)
+    if (!objet[VALIDATIONS])
+      objet[VALIDATIONS] = []
+    objet[VALIDATIONS].push(validateur(this.args))
+  }
+  visitInputFieldDefinition(champ) {
+    assurerSchemaProteges(this.schema)
+    if (!champ[VALIDATIONS])
+      champ[VALIDATIONS] = []
+    champ[VALIDATIONS].push(validateur(this.args))
+  }
+}

--- a/apollo-server/composants/validation/ValidationErreurs.js
+++ b/apollo-server/composants/validation/ValidationErreurs.js
@@ -1,0 +1,75 @@
+import CodinSchoolError from '../erreur'
+import { MODE_DEVELOPPEMENT } from '../config'
+
+const probleme = (code, message, emplacement, meta) => ({
+  code,
+  message,
+  emplacement,
+  meta
+})
+
+export class ValidationError extends CodinSchoolError {
+  constructor(...problemes) {
+    super('VALIDATION_ECHOUEE', 'Des données invalides ont été passé dans cette requête.', { problemes })
+    this.problemes = problemes
+  }
+}
+
+export const erreurInattendueProbleme = (emplacement, erreurInitiale) => probleme(
+  'VALIDATION_ERREUR_INTERNE',
+  'Une erreur inattendue est survenue lors de la validation.',
+  emplacement,
+  MODE_DEVELOPPEMENT ? erreurInitiale : undefined
+)
+
+export const egaliteProbleme = (emplacement, attendu, recu) => probleme(
+  'VALIDATION_EGALITE',
+  `« ${recu} » reçu alors que « ${attendu} » était attendu.`,
+  emplacement,
+  {
+    attendu,
+    recu
+  }
+)
+
+export const typeProbleme = (emplacement, attendu, recu, valeur) => probleme(
+  'VALIDATION_TYPE',
+  `Type « ${attendu} » attendu, « ${recu} » reçu. Valeur : « ${valeur} ».`,
+  emplacement,
+  {
+    attendu,
+    recu,
+    valeur
+  }
+)
+
+export const proprieteManquanteProbleme = (emplacement, nom) => probleme(
+  'VALIDATION_PROPRIÉTÉ_MANQUANTE',
+  `Propriété « ${nom} » manquante.`,
+  emplacement,
+  {
+    nom
+  }
+)
+
+export const longueurMaxProbleme = (emplacement, longueur, valeur) => probleme(
+  'VALIDATION_LONGUEUR_MAX',
+  `Valeur trop longue. Taille maximale: ${longueur} caractère(s) (${valeur.length} reçu(s)).`,
+  emplacement,
+  {
+    max: longueur,
+    recu: valeur.length,
+    valeur
+  }
+)
+
+export const longueurMinProbleme = (emplacement, longueur, valeur) => probleme(
+  'VALIDATION_LONGUEUR_MIN',
+  `Valeur trop courte. Taille minimale: ${longueur} caractère(s) (${valeur.length} reçu(s)).`,
+  emplacement,
+  {
+    min: longueur,
+    recu: valeur.length,
+    valeur
+  }
+)

--- a/apollo-server/composants/validation/ValidationTexte.graphql
+++ b/apollo-server/composants/validation/ValidationTexte.graphql
@@ -1,0 +1,7 @@
+directive @min(
+  longueur: Int!
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @max(
+  longueur: Int!
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION

--- a/apollo-server/composants/validation/ValidationTexte.js
+++ b/apollo-server/composants/validation/ValidationTexte.js
@@ -1,0 +1,46 @@
+import { ValidationError, typeProbleme, longueurMaxProbleme, longueurMinProbleme } from './ValidationErreurs'
+import validateurVersDirective from './Directive'
+
+/**
+ * Convertir une chaîne en kebab case sans accent ni symboles interdits.
+ *
+ * @param {string} chaineAConvertir la chaîne à convertir
+ * @returns {string} la chaîne en kebab case
+ */
+export const casseKebab = chaineAConvertir => chaineAConvertir
+  .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+  .replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/\s+]/gi, '-')
+  .replace(/\-+/g, '-')
+  .replace(/^\-|\-$/g, '')
+  .toLowerCase()
+
+export const estCasseKebab = chaineATester => /^(?:(?:[a-z0-9]+)-)*(?:[a-z0-9]+)$/.test(chaineATester)
+
+export const estTexteValidateur = (valeurAValider, emplacement = '') => {
+  if (typeof valeurAValider !== 'string')
+    throw new ValidationError(
+      typeProbleme(emplacement, 'string', typeof valeurAValider, valeurAValider)
+    )
+  return valeurAValider
+}
+
+export const longueurMinValidateur = longueurMin => (valeurAValider, emplacement = '') => {
+  if (typeof valeurAValider !== 'string' || (valeurAValider.length < longueurMin))
+    throw new ValidationError(
+      longueurMinProbleme(emplacement, longueurMin, valeurAValider)
+    )
+  return valeurAValider
+}
+
+export const longueurMaxValidateur = longueurMax => (valeurAValider, emplacement = '') => {
+  if (typeof valeurAValider !== 'string' || (valeurAValider.length > longueurMax))
+    throw new ValidationError(
+      longueurMaxProbleme(emplacement, longueurMax, valeurAValider)
+    )
+  return valeurAValider
+}
+
+export const directives = {
+  min: validateurVersDirective(({ longueur }) => longueurMinValidateur(longueur)),
+  max: validateurVersDirective(({ longueur }) => longueurMaxValidateur(longueur))
+}

--- a/apollo-server/composants/validation/index.graphql
+++ b/apollo-server/composants/validation/index.graphql
@@ -1,0 +1,1 @@
+#import * from "./ValidationTexte.graphql"

--- a/apollo-server/composants/validation/index.js
+++ b/apollo-server/composants/validation/index.js
@@ -1,0 +1,94 @@
+import { ValidationError, egaliteProbleme } from './ValidationErreurs'
+import { directives as texteDirectives } from './ValidationTexte'
+
+export * from './ValidationTexte'
+
+export const egaliteValidateur = valeurAttendue => (valeurAValider, emplacement = '') => {
+  if (valeurAValider !== valeurAttendue)
+    throw new ValidationError(
+      egaliteProbleme(emplacement, valeurAttendue, valeurAValider)
+    )
+  return valeurAValider
+}
+export const parallelValidateur = (...validateurs) => async (valeurAValider, emplacement = '') => {
+  const erreursRencontree = []
+  for (let validateur of validateurs)
+    try {
+      await validateur(valeurAValider, emplacement)
+    }
+    catch (err) {
+      erreursRencontree.push(err)
+    }
+  if (erreursRencontree.length)
+    throw new ValidationError(...erreursRencontree.map(v => v.problemes))
+  return valeurAValider
+}
+export const objetValidateur = definition => async (objAValider, emplacement = '') => {
+  // const objetSain = Object.create(null)
+  const erreursRencontree = []
+  const objetSain = {}
+  for (let [cle, validateur] of definition) {
+    try {
+      const valeurInitiale = objAValider[cle]
+      const nouvelleValeur = await validateur(objAValider[cle], `${emplacement}.${cle}`)
+      objetSain[cle] = nouvelleValeur === undefined
+        ? valeurInitiale
+        : nouvelleValeur
+    }
+    catch (err) {
+      erreursRencontree.push(err)
+    }
+  }
+  if (erreursRencontree.length)
+    throw new ValidationError(...erreursRencontree.map(v => v.problemes))
+  return objetSain
+}
+
+const VISITE_EN_COURS = Symbol()
+
+export default function construireValidation(definition) {
+  if (definition instanceof Function)
+    return definition
+  else if (Array.isArray(definition))
+    return parallelValidateur(...definition.map(construireValidation))
+  else if (typeof definition === 'object')
+    try {
+      if (VISITE_EN_COURS in definition)
+        return
+      definition[VISITE_EN_COURS] = true
+      return objetValidateur(Object
+        .entries(definition)
+        .map(([cle, valeur]) => [cle, construireValidation(valeur)])
+      )
+    }
+    finally {
+      delete definition[VISITE_EN_COURS]
+    }
+  else
+    return egaliteValidateur(definition)
+}
+
+export const sequenceValidateur = (...validateurs) => {
+  validateurs = validateurs.map(construireValidation)
+  return async (valeurAValider, emplacement = '') => {
+    let valeurActuelle = valeurAValider
+    for (let validateur of validateurs) {
+      const nouvelleValeur = await validateur(valeurActuelle, emplacement)
+      if (nouvelleValeur !== undefined)
+        valeurActuelle = nouvelleValeur
+    }
+    return valeurActuelle
+  }
+}
+
+export const optionnelValidateur = definition => {
+  definition = construireValidation(definition)
+  return async (valeurAValider, emplacement = '') =>
+    valeurAValider !== undefined
+      ? definition(valeurAValider, emplacement)
+      : undefined
+}
+
+export const directives = {
+  ...texteDirectives
+}

--- a/apollo-server/directives.js
+++ b/apollo-server/directives.js
@@ -1,5 +1,7 @@
 import { DirectiveAcces } from './composants/auth'
+import { directives } from './composants/validation'
 
 export default {
-  acces: DirectiveAcces
+  acces: DirectiveAcces,
+  ...directives
 }

--- a/apollo-server/schema.graphql
+++ b/apollo-server/schema.graphql
@@ -1,3 +1,5 @@
+#import * from "./composants/validation/index.graphql"
+
 #import * from "./composants/role/index.graphql"
 #import * from "./composants/auth/index.graphql"
 #import * from "./composants/niveau/index.graphql"


### PR DESCRIPTION
Fix #44

## Problème

Actuellement, le serveur n'effectue pas de validation sur les données entrantes. Seule les contraintes de la Base de Données sont utilisées, bien que les erreurs générés pour une violation de ces contraintes ne soient pas traitées, résultant en une impossibilité de les traiter côté *front*.

## Solution

Cette *Pull Request* ajoute un mécanisme de validation au niveau de GraphQL, permettant d'ajouter des contraintes directement dans le schéma GraphQL au niveau des type `Input`.

## Exemple

https://github.com/Minigugus/CodinSchool/blob/be0c66a816f454421f9c171310f3d0b319debae5/apollo-server/composants/niveau/index.graphql#L28-L39

## État

Validations ajoutées par composant :
 * [x] Niveaux
 * [ ] Exercice
   * [ ] Soumission (incomplet sur cette branche)
   * [ ] Test
 * [ ] Utilisateur