### PR TITLE
Changement d'exercice d'un test

### DIFF
--- a/apollo-server/composants/exercice/test/TestResolvers.js
+++ b/apollo-server/composants/exercice/test/TestResolvers.js
@@ -1,6 +1,11 @@
-import { creerTest, editerTest, supprimerTest, reorganiserTests } from './TestLogique'
+import { creerTest, editerTest, supprimerTest, reorganiserTests, recupererParID } from './TestLogique'
 
 export default {
+  Query: {
+    test(_, { id }) {
+      return recupererParID(id)
+    }
+  },
   Mutation: {
     creerTest(_, { exercice, test }) {
       return creerTest(exercice, test)

--- a/apollo-server/composants/exercice/test/TestResolvers.js
+++ b/apollo-server/composants/exercice/test/TestResolvers.js
@@ -10,8 +10,8 @@ export default {
     creerTest(_, { exercice, test }) {
       return creerTest(exercice, test)
     },
-    editerTest(_, { id, modifications }) {
-      return editerTest(id, modifications)
+    editerTest(_, { id, test }) {
+      return editerTest(id, test)
     },
     supprimerTest(_, { test }) {
       return supprimerTest(test)

--- a/apollo-server/composants/exercice/test/index.graphql
+++ b/apollo-server/composants/exercice/test/index.graphql
@@ -23,6 +23,8 @@ input CreationTest {
 }
 
 input EditionTest {
+  exerciceId: ID
+
   nom: String
   entree: String
   sortie: String

--- a/apollo-server/composants/exercice/test/index.graphql
+++ b/apollo-server/composants/exercice/test/index.graphql
@@ -9,7 +9,7 @@ type Mutation {
   creerTest(exercice: ID!, test: CreationTest!): Test!
   @acces(requis: [ GESTION_EXERCICE ])
 
-  editerTest(id: ID!, modifications: EditionTest!): Test!
+  editerTest(id: ID!, test: EditionTest!): Test!
   @acces(requis: [ GESTION_EXERCICE ])
 
   reorganiserTests(exercice: ID!, tests: [ID!]!): [Test!]!

--- a/apollo-server/composants/exercice/test/index.graphql
+++ b/apollo-server/composants/exercice/test/index.graphql
@@ -1,5 +1,9 @@
 #import * from "./Test.graphql"
 
+type Query {
+  test(id: ID!): Test!
+}
+
 type Mutation {
 
   creerTest(exercice: ID!, test: CreationTest!): Test!


### PR DESCRIPTION
Fix #45
## Description
Cette PR corrige les problèmes suivants :
 * Il est actuellement impossible de changer l'*Exercice* auquel appartient un *Test* sans utiliser la  réorganisation de l'Exercice.
https://github.com/Minigugus/CodinSchool/blob/b87529cf2ff6f28ec54392145ec6cfe69f4f0a1a/apollo-server/composants/exercice/test/index.graphql#L25-L28
 * Il n'est pas non plus possible de récupérer un *Test* en particulier.
https://github.com/Minigugus/CodinSchool/blob/6c681c7adb4f83040fcf8c5ea0c90e6d218b4eeb/apollo-server/composants/exercice/test/index.graphql#L3-L5
 * La mutation `editerTest` n'est pas consistante avec `editerExercice` et `editerNiveau` : le 2ème paramètre s'appelle `modifications` alors qu'il s'agit respectivement de `exercice` et `niveau` pour les *Exerices* et *Niveaux*.
https://github.com/Minigugus/CodinSchool/blob/3e287e058893babd01dfe30e17e3a4c04641975f/apollo-server/composants/exercice/test/index.graphql#L12

@rigwild Je te laisse adapter le code sur le front si besoin est.

